### PR TITLE
Add mock NFT gallery and tracking API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # nft-gratitude-board
+
+This is a minimal Next.js dApp that lets users create, store and share messages of gratitude as NFTs on the Sui blockchain.
+
+## Features
+
+- Connect Sui wallet using `@mysten/wallet-kit`.
+- Responsive navbar with wallet button.
+- Simple form to mint new NFTs (placeholder transaction logic) and track mints via an API route.
+- Gallery page shows a mock list of NFTs.
+
+> **Note**: Dependencies are declared in `package.json` but not installed in this environment.

--- a/components/ConnectWallet.tsx
+++ b/components/ConnectWallet.tsx
@@ -1,0 +1,15 @@
+import { useWallet } from '@mysten/wallet-kit';
+
+export default function ConnectWallet() {
+  const { connect, disconnect, connected, connecting, currentWallet } = useWallet();
+
+  return (
+    <button
+      onClick={connected ? disconnect : connect}
+      className="px-4 py-2 font-semibold text-white bg-purple-600 rounded hover:bg-purple-700 disabled:opacity-50"
+      disabled={connecting}
+    >
+      {connected ? 'Disconnect' : connecting ? 'Connecting...' : 'Connect Wallet'}
+    </button>
+  );
+}

--- a/components/MintDialog.tsx
+++ b/components/MintDialog.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useWallet } from '@mysten/wallet-kit';
+
+export default function MintDialog({ onMinted }: { onMinted: () => void }) {
+  const { signAndExecuteTransactionBlock } = useWallet();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [imageUrl, setImageUrl] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const handleMint = async () => {
+    setLoading(true);
+    try {
+      // TODO: build transaction block and call move package
+      const result = await signAndExecuteTransactionBlock({ transactionBlock: {} as any });
+      await fetch('/api/track', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'mint', digest: result?.digest ?? null })
+      });
+      onMinted();
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="p-4 bg-white rounded shadow-md space-y-4">
+      <h2 className="text-xl font-bold">Create NFT</h2>
+      <input
+        className="w-full border p-2 rounded"
+        placeholder="Title"
+        value={title}
+        onChange={(e) => setTitle(e.target.value)}
+      />
+      <textarea
+        className="w-full border p-2 rounded"
+        placeholder="Description"
+        value={description}
+        onChange={(e) => setDescription(e.target.value)}
+      />
+      <input
+        className="w-full border p-2 rounded"
+        placeholder="Image URL (optional)"
+        value={imageUrl}
+        onChange={(e) => setImageUrl(e.target.value)}
+      />
+      <button
+        onClick={handleMint}
+        disabled={loading}
+        className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700 disabled:opacity-50"
+      >
+        {loading ? 'Minting...' : 'Mint NFT'}
+      </button>
+    </div>
+  );
+}

--- a/components/NFTCard.tsx
+++ b/components/NFTCard.tsx
@@ -1,0 +1,21 @@
+import Image from 'next/image';
+import { NFT } from '../lib/mock-nfts';
+
+export default function NFTCard({ nft }: { nft: NFT }) {
+  return (
+    <div className="bg-white rounded shadow p-4 space-y-2">
+      {nft.imageUrl && (
+        <div className="relative w-full h-48">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={nft.imageUrl}
+            alt={nft.title}
+            className="object-cover w-full h-full rounded"
+          />
+        </div>
+      )}
+      <h3 className="text-lg font-semibold truncate">{nft.title}</h3>
+      <p className="text-sm text-gray-700 line-clamp-2">{nft.description}</p>
+    </div>
+  );
+}

--- a/components/NFTList.tsx
+++ b/components/NFTList.tsx
@@ -1,0 +1,15 @@
+import NFTCard from './NFTCard';
+import { NFT } from '../lib/mock-nfts';
+
+export default function NFTList({ nfts }: { nfts: NFT[] }) {
+  if (!nfts.length) {
+    return <p>No NFTs found.</p>;
+  }
+  return (
+    <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
+      {nfts.map((nft) => (
+        <NFTCard key={nft.id} nft={nft} />
+      ))}
+    </div>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -1,0 +1,39 @@
+import Link from 'next/link';
+import ConnectWallet from './ConnectWallet';
+import { useState } from 'react';
+
+export default function Navbar() {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <nav className="bg-white shadow-md sticky top-0 z-10">
+      <div className="max-w-6xl mx-auto px-4">
+        <div className="flex justify-between h-16 items-center">
+          <Link href="/" className="text-xl font-bold text-purple-600">NFT Gratitude</Link>
+          <div className="hidden md:flex space-x-4">
+            <Link href="/" className="hover:text-purple-600">Home</Link>
+            <Link href="/gallery" className="hover:text-purple-600">Gallery</Link>
+            <Link href="#" className="hover:text-purple-600">Create NFT</Link>
+            <Link href="#" className="hover:text-purple-600">Guide</Link>
+          </div>
+          <div className="hidden md:block">
+            <ConnectWallet />
+          </div>
+          <button className="md:hidden" onClick={() => setOpen(!open)}>
+            <span className="sr-only">Toggle Menu</span>
+            <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M4 6h16M4 12h16M4 18h16"></path></svg>
+          </button>
+        </div>
+        {open && (
+          <div className="md:hidden pb-4 space-y-2">
+            <Link href="/" className="block" onClick={() => setOpen(false)}>Home</Link>
+            <Link href="/gallery" className="block" onClick={() => setOpen(false)}>Gallery</Link>
+            <Link href="#" className="block" onClick={() => setOpen(false)}>Create NFT</Link>
+            <Link href="#" className="block" onClick={() => setOpen(false)}>Guide</Link>
+            <ConnectWallet />
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/lib/mock-nfts.ts
+++ b/lib/mock-nfts.ts
@@ -1,0 +1,27 @@
+export interface NFT {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+}
+
+export const mockNFTs: NFT[] = [
+  {
+    id: '1',
+    title: 'Gratitude to Mom',
+    description: 'Thanks for always being there!',
+    imageUrl: 'https://via.placeholder.com/300x200.png?text=NFT+1'
+  },
+  {
+    id: '2',
+    title: 'Thank You Friend',
+    description: 'For all the good times together.',
+    imageUrl: 'https://via.placeholder.com/300x200.png?text=NFT+2'
+  },
+  {
+    id: '3',
+    title: 'Special Mentor',
+    description: 'Appreciate your guidance.',
+    imageUrl: 'https://via.placeholder.com/300x200.png?text=NFT+3'
+  }
+];

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "nft-gratitude-board",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "13.5.6",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "@mysten/wallet-kit": "^0.8.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.3.1",
+    "@types/react": "18.2.14",
+    "autoprefixer": "10.4.16",
+    "postcss": "8.4.21",
+    "tailwindcss": "3.3.3",
+    "typescript": "5.1.6"
+  }
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,0 +1,11 @@
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
+import { WalletProvider } from '@mysten/wallet-kit';
+
+export default function App({ Component, pageProps }: AppProps) {
+  return (
+    <WalletProvider>
+      <Component {...pageProps} />
+    </WalletProvider>
+  );
+}

--- a/pages/api/track.ts
+++ b/pages/api/track.ts
@@ -1,0 +1,10 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'POST') {
+    console.log('Track:', req.body);
+    res.status(200).json({ success: true });
+  } else {
+    res.status(405).end();
+  }
+}

--- a/pages/create.tsx
+++ b/pages/create.tsx
@@ -1,0 +1,32 @@
+import Navbar from '../components/Navbar';
+import Head from 'next/head';
+import { useState } from 'react';
+import MintDialog from '../components/MintDialog';
+
+export default function Create() {
+  const [show, setShow] = useState(false);
+
+  return (
+    <>
+      <Head>
+        <title>Create NFT - NFT Gratitude Board</title>
+      </Head>
+      <Navbar />
+      <main className="max-w-6xl mx-auto p-4 space-y-4">
+        <button
+          onClick={() => setShow(true)}
+          className="px-4 py-2 bg-purple-600 text-white rounded hover:bg-purple-700"
+        >
+          New NFT
+        </button>
+        {show && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center" onClick={() => setShow(false)}>
+            <div onClick={(e) => e.stopPropagation()}>
+              <MintDialog onMinted={() => setShow(false)} />
+            </div>
+          </div>
+        )}
+      </main>
+    </>
+  );
+}

--- a/pages/gallery.tsx
+++ b/pages/gallery.tsx
@@ -1,0 +1,19 @@
+import Navbar from '../components/Navbar';
+import Head from 'next/head';
+import NFTList from '../components/NFTList';
+import { mockNFTs } from '../lib/mock-nfts';
+
+export default function Gallery() {
+  return (
+    <>
+      <Head>
+        <title>Gallery - NFT Gratitude Board</title>
+      </Head>
+      <Navbar />
+      <main className="max-w-6xl mx-auto p-4 space-y-4">
+        <h1 className="text-2xl font-bold">Gallery</h1>
+        <NFTList nfts={mockNFTs} />
+      </main>
+    </>
+  );
+}

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,0 +1,17 @@
+import Navbar from '../components/Navbar';
+import Head from 'next/head';
+
+export default function Home() {
+  return (
+    <>
+      <Head>
+        <title>NFT Gratitude Board</title>
+      </Head>
+      <Navbar />
+      <main className="max-w-6xl mx-auto p-4 text-center">
+        <h1 className="text-4xl font-bold mb-4">Welcome to NFT Gratitude Board</h1>
+        <p className="mb-8">Create, store and share your gratitude as NFTs on Sui blockchain.</p>
+      </main>
+    </>
+  );
+}

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gradient-to-br from-purple-50 to-purple-100 text-gray-900;
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './pages/**/*.{js,ts,jsx,tsx}',
+    './components/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- list NFTs with new `NFTList` component and mock data
- log mint actions with an `/api/track` route
- call tracking API from the `MintDialog`
- update README to mention gallery and tracking

## Testing
- `npm run lint` *(fails: next not found)*